### PR TITLE
Fix component errors by providing lightning:card required title attribute

### DIFF
--- a/shipping-app-fedex/main/default/aura/fedExTracking/fedExTracking.cmp
+++ b/shipping-app-fedex/main/default/aura/fedExTracking/fedExTracking.cmp
@@ -1,7 +1,7 @@
 <aura:component>
     <aura:attribute name="recordId" type="String"/>
-    <lightning:card>
+    <lightning:card title="">
         <img src="{!$Resource.fedexlogo}"/>
         <div class="slds-p-around_x-small">FedEx Tracking {!v.recordId}</div>
     </lightning:card>
-</aura:component>	
+</aura:component>

--- a/shipping-app-ups/main/default/aura/upsTracking/upsTracking.cmp
+++ b/shipping-app-ups/main/default/aura/upsTracking/upsTracking.cmp
@@ -1,7 +1,7 @@
 <aura:component>
     <aura:attribute name="recordId" type="String"/>
-    <lightning:card>
+    <lightning:card title="">
         <img src="{!$Resource.upslogo}"/>
         <div class="slds-p-around_x-small">Ups Tracking {!v.recordId}</div>
     </lightning:card>
-</aura:component>	
+</aura:component>

--- a/shipping-app/main/default/aura/shipmentSupport/shipmentSupport.cmp
+++ b/shipping-app/main/default/aura/shipmentSupport/shipmentSupport.cmp
@@ -1,5 +1,5 @@
 <aura:component implements="flexipage:availableForAllPageTypes,force:hasRecordId">
-    <lightning:card>
+    <lightning:card title="">
         <c:di_injector bindingName="ShipmentSupport">
             <c:di_injectorAttribute name="recordId" value="{!v.recordId}"/>
         </c:di_injector>


### PR DESCRIPTION
In my testing, without the `title` attribute then I received the below errors. Adding the attribute, even with empty string value, resolves the issue.

![image](https://user-images.githubusercontent.com/4142577/44800771-d903cf00-ab7c-11e8-8bed-09d065ec9573.png)

![image](https://user-images.githubusercontent.com/4142577/44800773-db662900-ab7c-11e8-9d8c-8a80883a6ebf.png)
